### PR TITLE
Add new genre term

### DIFF
--- a/_data/elements/hasType.yml
+++ b/_data/elements/hasType.yml
@@ -100,6 +100,7 @@ range:
       - "programs (documents)"
       - "property records"
       - "questionnaires"
+      - "radio programs"
       - "reports"
       - "résumés (personnel records)"
       - "rosters"

--- a/guidelines/hasType.md
+++ b/guidelines/hasType.md
@@ -106,6 +106,7 @@ Use the capitalization below; pay close attention to terms that are pluralized.
 |programs (documents)|
 |property records|
 |questionnaires|
+|radio programs|
 |reports|
 |résumés (personnel records)|
 |rosters|


### PR DESCRIPTION
Added term for "radio programs" for use in Genre field for recordings of broadcasts, events, other programs originating on radio. http://vocab.getty.edu/aat/300387763