### PR TITLE
Add genre exhibition catalogs

### DIFF
--- a/_data/elements/hasType.yml
+++ b/_data/elements/hasType.yml
@@ -50,6 +50,7 @@ range:
       - "engravings (prints)"
       - "envelopes"
       - "essays"
+      - "exhibition catalogs"
       - "financial records"
       - "financial statements"
       - "fliers (printed matter)"

--- a/guidelines/hasType.md
+++ b/guidelines/hasType.md
@@ -58,6 +58,7 @@ Use the capitalization below; pay close attention to terms that are pluralized.
 |engravings (prints)|
 |envelopes|
 |essays|
+|exhibition catalogs|
 |financial records|
 |financial statements|
 |fliers (printed matter)|


### PR DESCRIPTION
Added genre "exhibition catalogs" which we will use for Blaffer and other digital collections. https://vocab.getty.edu/page/aat/300026096