### PR TITLE
Add genre instructional materials

### DIFF
--- a/_data/elements/hasType.yml
+++ b/_data/elements/hasType.yml
@@ -60,6 +60,7 @@ range:
       - "illuminated manuscripts"
       - "illustrations (layout features)"
       - "inscriptions"
+      - "instructional materials"
       - "instructions (document genre)"
       - "interviews"
       - "invitations"

--- a/guidelines/hasType.md
+++ b/guidelines/hasType.md
@@ -67,6 +67,7 @@ Use the capitalization below; pay close attention to terms that are pluralized.
 |illuminated manuscripts|
 |illustrations (layout features)|
 |inscriptions|
+|instructional materials|
 |instructions (document genre)|
 |interviews|
 |invitations|


### PR DESCRIPTION
Added "instructional materials" genre to be used initially for Teaching and Learning videos. http://vocab.getty.edu/aat/300026367