### PR TITLE
Add Norwegian language codes

### DIFF
--- a/_data/elements/language.yml
+++ b/_data/elements/language.yml
@@ -22,6 +22,9 @@ range:
       - kor
       - lat
       - nld
+      - nno
+      - nob
+      - nor
       - pol
       - por
       - srp

--- a/guidelines/language.md
+++ b/guidelines/language.md
@@ -28,6 +28,9 @@ Icelandic | `isl`
 Korean | `kor`
 Latin | `lat`
 Mandarin | `cmn` (when using this code, enter code `zho` for Chinese as well)
+Norwegian | `nor`
+Norwegian Bokmål | `nob` (when using this code, enter code `nor` for Norwegian as well)
+Norwegian Nynorsk | `nno` (when using this code, enter code `nor` for Norwegian as well)
 Polish | `pol`
 Portuguese | `por`
 Serbian | `srp`


### PR DESCRIPTION
Added codes for Bokmål and Nynorsk, also Norwegian macrolanguage.